### PR TITLE
Fix player movement freezing at screen edges

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,12 +111,16 @@ class Player(pygame.sprite.Sprite):
         # if they are, stop the player
         if self.rect.left < 0:
             self.rect.left = 0
+            self.pos[0] = self.rect.centerx
         if self.rect.right > screen.get_rect().right:
             self.rect.right = screen.get_rect().right
+            self.pos[0] = self.rect.centerx
         if self.rect.top < 0:
             self.rect.top = 0
+            self.pos[1] = self.rect.centery
         if self.rect.bottom > screen.get_rect().bottom:
             self.rect.bottom = screen.get_rect().bottom
+            self.pos[1] = self.rect.centery
     
     def enemyCheck(self):
         # check if the player is touching an enemy

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-from distutils.log import warn
 import random
 import pygame
 import math
@@ -105,22 +104,12 @@ class Player(pygame.sprite.Sprite):
         self.pos[0] += x
         self.pos[1] += y
 
+        # clamp position within screen boundaries
+        self.pos[0] = max(self.rect.width / 2, min(self.pos[0], screen.get_width() - self.rect.width / 2))
+        self.pos[1] = max(self.rect.height / 2, min(self.pos[1], screen.get_height() - self.rect.height / 2))
+
         self.rect.centerx = self.pos[0]
         self.rect.centery = self.pos[1]
-        # check if the player is touching the screen borders
-        # if they are, stop the player
-        if self.rect.left < 0:
-            self.rect.left = 0
-            self.pos[0] = self.rect.centerx
-        if self.rect.right > screen.get_rect().right:
-            self.rect.right = screen.get_rect().right
-            self.pos[0] = self.rect.centerx
-        if self.rect.top < 0:
-            self.rect.top = 0
-            self.pos[1] = self.rect.centery
-        if self.rect.bottom > screen.get_rect().bottom:
-            self.rect.bottom = screen.get_rect().bottom
-            self.pos[1] = self.rect.centery
     
     def enemyCheck(self):
         # check if the player is touching an enemy
@@ -128,7 +117,6 @@ class Player(pygame.sprite.Sprite):
             if self.rect.colliderect(enemy.rect):
                 # stop the game
                 lose()
-
 class Enemy(pygame.sprite.Sprite):
     def __init__(self, type, x=None, y=None):
         pygame.sprite.Sprite.__init__(self)


### PR DESCRIPTION
Related to #1

Update `move` method in `Player` class to handle continuous movement input at screen edges.

* Modify the logic in the `move` method to update the player's position based on continuous input when touching the screen borders.
* Add lines to set `self.pos` to the player's center position when the player is at the screen edges.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/adamalbu/WAVE/pull/2?shareId=7d8d3cc9-7101-43f6-a0fd-988b2dccabc6).